### PR TITLE
[squid:S1149] Synchronized classes Vector, Hashtable, Stack and Strin

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/data/DataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/DataSet.java
@@ -122,7 +122,7 @@ public abstract class DataSet<T extends Entry> extends BaseDataSet<T> {
 
     @Override
     public String toString() {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         buffer.append(toSimpleString());
         for (int i = 0; i < mYVals.size(); i++) {
             buffer.append(mYVals.get(i).toString() + " ");
@@ -137,7 +137,7 @@ public abstract class DataSet<T extends Entry> extends BaseDataSet<T> {
      * @return
      */
     public String toSimpleString() {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         buffer.append("DataSet, label: " + (getLabel() == null ? "" : getLabel()) + ", entries: " + mYVals.size() + "\n");
         return buffer.toString();
     }

--- a/MPChartLib/src/com/github/mikephil/charting/formatter/DefaultValueFormatter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/formatter/DefaultValueFormatter.java
@@ -25,7 +25,7 @@ public class DefaultValueFormatter implements ValueFormatter {
      */
     public DefaultValueFormatter(int digits) {
 
-        StringBuffer b = new StringBuffer();
+        StringBuilder b = new StringBuilder();
         for (int i = 0; i < digits; i++) {
             if (i == 0)
                 b.append(".");

--- a/MPChartLib/src/com/github/mikephil/charting/formatter/DefaultYAxisValueFormatter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/formatter/DefaultYAxisValueFormatter.java
@@ -22,7 +22,7 @@ public class DefaultYAxisValueFormatter implements YAxisValueFormatter {
      */
     public DefaultYAxisValueFormatter(int digits) {
 
-        StringBuffer b = new StringBuffer();
+        StringBuilder b = new StringBuilder();
         for (int i = 0; i < digits; i++) {
             if (i == 0)
                 b.append(".");

--- a/MPChartLib/src/com/github/mikephil/charting/formatter/StackedValueFormatter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/formatter/StackedValueFormatter.java
@@ -37,7 +37,7 @@ public class StackedValueFormatter implements ValueFormatter {
         this.mDrawWholeStack = drawWholeStack;
         this.mAppendix = appendix;
 
-        StringBuffer b = new StringBuffer();
+        StringBuilder b = new StringBuilder();
         for (int i = 0; i < decimals; i++) {
             if (i == 0)
                 b.append(".");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.
Ayman Abdelghany.
