### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/data/realm/base/RealmUtils.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/realm/base/RealmUtils.java
@@ -12,6 +12,12 @@ import io.realm.RealmResults;
 public final class RealmUtils {
 
     /**
+     * Prevent class instantiation.
+     */
+    private RealmUtils() {
+    }
+
+    /**
      * Transforms the given Realm-ResultSet into a String array by using the provided xValuesField.
      *
      * @param result

--- a/MPChartLib/src/com/github/mikephil/charting/utils/FileUtils.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/FileUtils.java
@@ -27,6 +27,12 @@ import java.util.List;
 public class FileUtils {
 
     private static final String LOG = "MPChart-FileUtils";
+    
+    /**
+     * Prevent class instantiation.
+     */
+    private FileUtils() {
+    }
 
     /**
      * Loads a an Array of Entries from a textfile from the sd-card.

--- a/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
@@ -40,6 +40,12 @@ public abstract class Utils {
     private static int mMaximumFlingVelocity = 8000;
     public final static double DEG2RAD = (Math.PI / 180.0);
     public final static float FDEG2RAD = ((float) Math.PI / 180.f);
+    
+    /**
+     * Prevent class instantiation.
+     */
+    private Utils() {
+    }
 
     /**
      * initialize method, called inside the Chart.init() method.

--- a/app/src/main/java/com/example/yanjiang/stockchart/rxutils/MyUtils.java
+++ b/app/src/main/java/com/example/yanjiang/stockchart/rxutils/MyUtils.java
@@ -6,6 +6,12 @@ package com.example.yanjiang.stockchart.rxutils;
  * blog：http://blog.csdn.net/qqyanjiang
  */
 public class MyUtils {
+    /**
+     * Prevent class instantiation.
+     */
+    private MyUtils() {
+    }
+
     public static String getVolUnit(float num) {
 
         int e = (int) Math.floor(Math.log10(num));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
