### PR TITLE
[squid:MissingDeprecatedCheck] Deprecated elements should have both t

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/Chart.java
@@ -636,6 +636,7 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
     }
 
     /**
+     * @deprecated Kept for backward compatibility.
      * Deprecated. Calls highlightValue(high, true)
      */
     @Deprecated

--- a/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
@@ -277,6 +277,7 @@ public class PieChart extends PieRadarChartBase<PieData> {
     }
 
     /**
+     * @deprecated Kept for backward compatibility.
      * This will throw an exception, PieChart has no XAxis object.
      *
      * @return

--- a/MPChartLib/src/com/github/mikephil/charting/components/YAxis.java
+++ b/MPChartLib/src/com/github/mikephil/charting/components/YAxis.java
@@ -347,6 +347,7 @@ public class YAxis extends AxisBase {
     }
 
     /**
+     * @deprecated Kept for backward compatibility.
      * This method is deprecated.
      * Use setAxisMinValue(...) / setAxisMaxValue(...) instead.
      *

--- a/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
@@ -156,6 +156,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
     }
 
     /**
+     * @deprecated Kept for backward compatibility.
      * sets the size (radius) of the circle shpaed value indicators,
      * default size = 4f
      *
@@ -169,7 +170,7 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
     }
 
     /**
-     *
+     * @deprecated Kept for backward compatibility.
      * This function is deprecated because of unclarity. Use getCircleRadius instead.
      *
      */
@@ -225,22 +226,38 @@ public class LineDataSet extends LineRadarDataSet<Entry> implements ILineDataSet
         return mDrawCircles;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param enabled
+     */
     @Deprecated
     public void setDrawCubic(boolean enabled) {
         mMode = enabled ? Mode.CUBIC_BEZIER : Mode.LINEAR;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @return
+     */
     @Deprecated
     @Override
     public boolean isDrawCubicEnabled() {
         return mMode == Mode.CUBIC_BEZIER;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param enabled
+     */
     @Deprecated
     public void setDrawStepped(boolean enabled) {
         mMode = enabled ? Mode.STEPPED : Mode.LINEAR;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @return
+     */
     @Deprecated
     @Override
     public boolean isDrawSteppedEnabled() {

--- a/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmLineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmLineDataSet.java
@@ -218,22 +218,38 @@ public class RealmLineDataSet<T extends RealmObject> extends RealmLineRadarDataS
         return mDrawCircles;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param enabled
+     */
     @Deprecated
     public void setDrawCubic(boolean enabled) {
         mMode = enabled ? LineDataSet.Mode.CUBIC_BEZIER : LineDataSet.Mode.LINEAR;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @return
+     */
     @Deprecated
     @Override
     public boolean isDrawCubicEnabled() {
         return mMode == LineDataSet.Mode.CUBIC_BEZIER;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @param enabled
+     */
     @Deprecated
     public void setDrawStepped(boolean enabled) {
         mMode = enabled ? LineDataSet.Mode.STEPPED : LineDataSet.Mode.LINEAR;
     }
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @return
+     */
     @Deprecated
     @Override
     public boolean isDrawSteppedEnabled() {

--- a/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
@@ -27,9 +27,17 @@ public interface ILineDataSet extends ILineRadarDataSet<Entry> {
      */
     float getCubicIntensity();
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @return
+     */
     @Deprecated
     boolean isDrawCubicEnabled();
 
+    /**
+     * @deprecated Kept for backward compatibility.
+     * @return
+     */
     @Deprecated
     boolean isDrawSteppedEnabled();
 

--- a/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
@@ -69,6 +69,7 @@ public abstract class Utils {
     }
 
     /**
+     * @deprecated Kept for backward compatibility.
      * initialize method, called inside the Chart.init() method. backwards
      * compatibility - to not break existing code
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:MissingDeprecatedCheck - “ Deprecated elements should have both the annotation and the Javadoc tag ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck

Please let me know if you have any questions.
Ayman Abdelghany.
