### PR TITLE
[squid:UselessParenthesesCheck] Useless parentheses around expressions should be removed

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -812,7 +812,7 @@ public abstract class BarLineChartBase<T extends BarLineScatterCandleBubbleData<
      * @param minXRange The minimum visible range of x-values.
      */
     public void setVisibleXRangeMinimum(float minXRange) {
-        float xScale = mXAxis.mAxisRange / (minXRange);
+        float xScale = mXAxis.mAxisRange / minXRange;
         mViewPortHandler.setMaximumScaleX(xScale);
     }
 

--- a/MPChartLib/src/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
+++ b/MPChartLib/src/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
@@ -103,7 +103,7 @@ public class BarLineChartTouchListener extends ChartTouchListener<BarLineChartBa
             mGestureDetector.onTouchEvent(event);
         }
 
-        if (!mChart.isDragEnabled() && (!mChart.isScaleXEnabled() && !mChart.isScaleYEnabled()))
+        if (!mChart.isDragEnabled() && !mChart.isScaleXEnabled() && !mChart.isScaleYEnabled())
             return true;
 
         // Handle touch events here...
@@ -353,8 +353,8 @@ public class BarLineChartTouchListener extends ChartTouchListener<BarLineChartBa
                             h.canZoomOutMoreY() :
                             h.canZoomInMoreY();
 
-                    float scaleX = (mChart.isScaleXEnabled()) ? scale : 1f;
-                    float scaleY = (mChart.isScaleYEnabled()) ? scale : 1f;
+                    float scaleX = mChart.isScaleXEnabled() ? scale : 1f;
+                    float scaleY = mChart.isScaleYEnabled() ? scale : 1f;
 
                     if (canZoomMoreY || canZoomMoreX) {
 

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
@@ -172,7 +172,7 @@ public class BubbleChartRenderer extends DataRenderer {
                     if (!mViewPortHandler.isInBoundsRight(x))
                         break;
 
-                    if ((!mViewPortHandler.isInBoundsLeft(x) || !mViewPortHandler.isInBoundsY(y)))
+                    if (!mViewPortHandler.isInBoundsLeft(x) || !mViewPortHandler.isInBoundsY(y))
                         continue;
 
                     BubbleEntry entry = dataSet.getEntryForIndex(j / 2 + minx);

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -199,7 +199,7 @@ public class PieChartRenderer extends DataRenderer {
         int visibleAngleCount = 0;
         for (int j = 0; j < entryCount; j++) {
             // draw only if the value is greater than zero
-            if ((Math.abs(dataSet.getEntryForIndex(j).getVal()) > 0.000001)) {
+            if (Math.abs(dataSet.getEntryForIndex(j).getVal()) > 0.000001) {
                 visibleAngleCount++;
             }
         }
@@ -214,7 +214,7 @@ public class PieChartRenderer extends DataRenderer {
             Entry e = dataSet.getEntryForIndex(j);
 
             // draw only if the value is greater than zero
-            if ((Math.abs(e.getVal()) > 0.000001)) {
+            if (Math.abs(e.getVal()) > 0.000001) {
 
                 if (!mChart.needsHighlight(e.getXIndex(),
                         mChart.getData().getIndexOfDataSet(dataSet))) {
@@ -709,7 +709,7 @@ public class PieChartRenderer extends DataRenderer {
             int visibleAngleCount = 0;
             for (int j = 0; j < entryCount; j++) {
                 // draw only if the value is greater than zero
-                if ((Math.abs(set.getEntryForIndex(j).getVal()) > 0.000001)) {
+                if (Math.abs(set.getEntryForIndex(j).getVal()) > 0.000001) {
                     visibleAngleCount++;
                 }
             }
@@ -898,7 +898,7 @@ public class PieChartRenderer extends DataRenderer {
             Entry e = dataSet.getEntryForIndex(j);
 
             // draw only if the value is greater than zero
-            if ((Math.abs(e.getVal()) > 0.000001)) {
+            if (Math.abs(e.getVal()) > 0.000001) {
 
                 float x = (float) ((r - circleRadius)
                         * Math.cos(Math.toRadians((angle + sliceAngle)

--- a/MPChartLib/src/com/github/mikephil/charting/utils/Transformer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/Transformer.java
@@ -51,8 +51,8 @@ public class Transformer {
      */
     public void prepareMatrixValuePx(float xChartMin, float deltaX, float deltaY, float yChartMin) {
 
-        float scaleX = (float) ((mViewPortHandler.contentWidth()) / deltaX);
-        float scaleY = (float) ((mViewPortHandler.contentHeight()) / deltaY);
+        float scaleX = (float) (mViewPortHandler.contentWidth() / deltaX);
+        float scaleY = (float) (mViewPortHandler.contentHeight() / deltaY);
 
         if (Float.isInfinite(scaleX))
         {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.
Ayman Abdelghany.
