### PR TITLE
[squid:S1132] Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/Chart.java
@@ -459,7 +459,7 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
      */
     protected void drawDescription(Canvas c) {
 
-        if (!mDescription.equals("")) {
+        if (!"".equals(mDescription)) {
 
             if (mDescriptionPosition == null) {
 

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -286,7 +286,7 @@ public class XAxisRenderer extends AxisRenderer {
         String label = limitLine.getLabel();
 
         // if drawing the limit-value label is enabled
-        if (label != null && !label.equals("")) {
+        if (label != null && !"".equals(label)) {
 
             mLimitLinePaint.setStyle(limitLine.getTextStyle());
             mLimitLinePaint.setPathEffect(null);

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRendererHorizontalBarChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/XAxisRendererHorizontalBarChart.java
@@ -230,7 +230,7 @@ public class XAxisRendererHorizontalBarChart extends XAxisRendererBarChart {
 			String label = l.getLabel();
 
 			// if drawing the limit-value label is enabled
-			if (label != null && !label.equals("")) {
+			if (label != null && !"".equals(label)) {
 
 				mLimitLinePaint.setStyle(l.getTextStyle());
 				mLimitLinePaint.setPathEffect(null);

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRenderer.java
@@ -373,7 +373,7 @@ public class YAxisRenderer extends AxisRenderer {
             String label = l.getLabel();
 
             // if drawing the limit-value label is enabled
-            if (label != null && !label.equals("")) {
+            if (label != null && !"".equals(label)) {
 
                 mLimitLinePaint.setStyle(l.getTextStyle());
                 mLimitLinePaint.setPathEffect(null);

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRendererHorizontalBarChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRendererHorizontalBarChart.java
@@ -235,7 +235,7 @@ public class YAxisRendererHorizontalBarChart extends YAxisRenderer {
             String label = l.getLabel();
 
             // if drawing the limit-value label is enabled
-            if (label != null && !label.equals("")) {
+            if (label != null && !"".equals(label)) {
 
                 mLimitLinePaint.setStyle(l.getTextStyle());
                 mLimitLinePaint.setPathEffect(null);

--- a/app/src/main/java/com/example/yanjiang/stockchart/KLineActivity.java
+++ b/app/src/main/java/com/example/yanjiang/stockchart/KLineActivity.java
@@ -190,9 +190,9 @@ public class KLineActivity extends BaseActivity {
         axisLeftBar.setAxisMaxValue(mData.getVolmax());
         String unit = MyUtils.getVolUnit(mData.getVolmax());
         int u = 1;
-        if (unit.equals("万手")) {
+        if ("万手".equals(unit)) {
             u = 4;
-        } else if (unit.equals("亿手")) {
+        } else if ("亿手".equals(unit)) {
             u = 8;
         }
         axisLeftBar.setValueFormatter(new VolFormatter((int) Math.pow(10, u)));

--- a/app/src/main/java/com/example/yanjiang/stockchart/MinutesActivity.java
+++ b/app/src/main/java/com/example/yanjiang/stockchart/MinutesActivity.java
@@ -244,9 +244,9 @@ public class MinutesActivity extends BaseActivity {
         /*单位*/
         String unit = MyUtils.getVolUnit(mData.getVolmax());
         int u = 1;
-        if (unit.equals("万手")) {
+        if ("万手".equals(unit)) {
             u = 4;
-        } else if (unit.equals("亿手")) {
+        } else if ("亿手".equals(unit)) {
             u = 8;
         }
         /*次方*/

--- a/app/src/main/java/com/example/yanjiang/stockchart/interceptor/HttpInterceptor.java
+++ b/app/src/main/java/com/example/yanjiang/stockchart/interceptor/HttpInterceptor.java
@@ -38,7 +38,7 @@ public class HttpInterceptor implements Interceptor {
         String cookie = sharedPreferences.getString("cookie", "");
         Request request = chain.request();
         Response response;
-        if (!cookie.equals("")) {
+        if (!"".equals(cookie)) {
             Request compressedRequest = request.newBuilder()
                     .header("Content-type","application/x-www-form-urlencoded; charset=UTF-8")
                     .header("cookie", cookie.substring(0,cookie.length()-1))

--- a/app/src/main/java/com/example/yanjiang/stockchart/interceptor/LoggingInterceptor.java
+++ b/app/src/main/java/com/example/yanjiang/stockchart/interceptor/LoggingInterceptor.java
@@ -45,13 +45,13 @@ public class LoggingInterceptor implements Interceptor {
 
         double time = (t2 - t1) / 1e6d;
 
-        if (request.method().equals("GET")) {
+        if ("GET".equals(request.method())) {
             System.out.println(String.format("GET " + F_REQUEST_WITHOUT_BODY + F_RESPONSE_WITH_BODY, request.url(), time, request.headers(), response.code(), response.headers(), stringifyResponseBody(bodyString)));
-        } else if (request.method().equals("POST")) {
+        } else if ("POST".equals(request.method())) {
             System.out.println(String.format("POST " + F_REQUEST_WITH_BODY + F_RESPONSE_WITH_BODY, request.url(), time, request.headers(), stringifyRequestBody(request), response.code(), response.headers(), stringifyResponseBody(bodyString)));
-        } else if (request.method().equals("PUT")) {
+        } else if ("PUT".equals(request.method())) {
             System.out.println(String.format("PUT " + F_REQUEST_WITH_BODY + F_RESPONSE_WITH_BODY, request.url(), time, request.headers(), request.body().toString(), response.code(), response.headers(), stringifyResponseBody(bodyString)));
-        } else if (request.method().equals("DELETE")) {
+        } else if ("DELETE".equals(request.method())) {
             System.out.println(String.format("DELETE " + F_REQUEST_WITHOUT_BODY + F_RESPONSE_WITHOUT_BODY, request.url(), time, request.headers(), response.code(), response.headers()));
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1132 - “Strings literals should be placed on the left side when checking for equality”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.
Ayman Abdelghany.
