### PR TITLE
[squid:S1126] Return of boolean expressions should not be wrapped into an "if-then-else" statement

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/Chart.java
@@ -353,10 +353,7 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
             return true;
         else {
 
-            if (mData.getYValCount() <= 0)
-                return true;
-            else
-                return false;
+            return mData.getYValCount() <= 0;
         }
     }
 

--- a/MPChartLib/src/com/github/mikephil/charting/components/YAxis.java
+++ b/MPChartLib/src/com/github/mikephil/charting/components/YAxis.java
@@ -560,11 +560,8 @@ public class YAxis extends AxisBase {
      * @return
      */
     public boolean needsOffset() {
-        if (isEnabled() && isDrawLabelsEnabled() && getLabelPosition() == YAxisLabelPosition
-                .OUTSIDE_CHART)
-            return true;
-        else
-            return false;
+        return (isEnabled() && isDrawLabelsEnabled() && getLabelPosition() == YAxisLabelPosition
+                .OUTSIDE_CHART);
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/highlight/Highlight.java
+++ b/MPChartLib/src/com/github/mikephil/charting/highlight/Highlight.java
@@ -147,11 +147,8 @@ public class Highlight {
         if (h == null)
             return false;
         else {
-            if (this.mDataSetIndex == h.mDataSetIndex && this.mXIndex == h.mXIndex
-                    && this.mStackIndex == h.mStackIndex)
-                return true;
-            else
-                return false;
+            return (this.mDataSetIndex == h.mDataSetIndex && this.mXIndex == h.mXIndex
+                    && this.mStackIndex == h.mStackIndex);
         }
     }
 

--- a/MPChartLib/src/com/github/mikephil/charting/highlight/Range.java
+++ b/MPChartLib/src/com/github/mikephil/charting/highlight/Range.java
@@ -22,10 +22,7 @@ public final class Range {
 	 */
 	public boolean contains(float value) {
 
-		if (value > from && value <= to)
-			return true;
-		else
-			return false;
+		return (value > from && value <= to);
 	}
 
 	public boolean isLarger(float value) {

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/Renderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/Renderer.java
@@ -37,10 +37,7 @@ public abstract class Renderer {
      */
     protected boolean fitsBounds(float val, float min, float max) {
 
-        if (val < min || val > max)
-            return false;
-        else
-            return true;
+        return !(val < min || val > max);
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/utils/ViewPortHandler.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/ViewPortHandler.java
@@ -106,10 +106,7 @@ public class ViewPortHandler {
     }
 
     public boolean hasChartDimens() {
-        if (mChartHeight > 0 && mChartWidth > 0)
-            return true;
-        else
-            return false;
+        return (mChartHeight > 0 && mChartWidth > 0);
     }
 
     public void restrainViewPort(float offsetLeft, float offsetTop, float offsetRight,
@@ -517,24 +514,15 @@ public class ViewPortHandler {
      */
 
     public boolean isInBoundsX(float x) {
-        if (isInBoundsLeft(x) && isInBoundsRight(x))
-            return true;
-        else
-            return false;
+        return (isInBoundsLeft(x) && isInBoundsRight(x));
     }
 
     public boolean isInBoundsY(float y) {
-        if (isInBoundsTop(y) && isInBoundsBottom(y))
-            return true;
-        else
-            return false;
+        return (isInBoundsTop(y) && isInBoundsBottom(y));
     }
 
     public boolean isInBounds(float x, float y) {
-        if (isInBoundsX(x) && isInBoundsY(y))
-            return true;
-        else
-            return false;
+        return (isInBoundsX(x) && isInBoundsY(y));
     }
 
     public boolean isInBoundsLeft(float x) {
@@ -610,10 +598,7 @@ public class ViewPortHandler {
      */
     public boolean isFullyZoomedOut() {
 
-        if (isFullyZoomedOutX() && isFullyZoomedOutY())
-            return true;
-        else
-            return false;
+        return (isFullyZoomedOutX() && isFullyZoomedOutY());
     }
 
     /**
@@ -622,10 +607,7 @@ public class ViewPortHandler {
      * @return
      */
     public boolean isFullyZoomedOutY() {
-        if (mScaleY > mMinScaleY || mMinScaleY > 1f)
-            return false;
-        else
-            return true;
+        return !(mScaleY > mMinScaleY || mMinScaleY > 1f);
     }
 
     /**
@@ -635,10 +617,7 @@ public class ViewPortHandler {
      * @return
      */
     public boolean isFullyZoomedOutX() {
-        if (mScaleX > mMinScaleX || mMinScaleX > 1f)
-            return false;
-        else
-            return true;
+        return !(mScaleX > mMinScaleX || mMinScaleX > 1f);
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1126 - “Return of boolean expressions should not be wrapped into an "if-then-else" statement”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1126

Please let me know if you have any questions.
Ayman Abdelghany.
