### PR TITLE
[squid:S2131] Primitives should not be boxed just for "String" conver

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/data/ChartData.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/ChartData.java
@@ -845,7 +845,7 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
         List<String> xvals = new ArrayList<String>();
 
         for (int i = from; i < to; i++) {
-            xvals.add("" + i);
+            xvals.add(Integer.toString(i));
         }
 
         return xvals;

--- a/app/src/main/java/com/example/yanjiang/stockchart/MinutesActivity.java
+++ b/app/src/main/java/com/example/yanjiang/stockchart/MinutesActivity.java
@@ -273,7 +273,7 @@ public class MinutesActivity extends BaseActivity {
         ArrayList<String> dateList = new ArrayList<String>();
         ArrayList<BarEntry> barEntries = new ArrayList<BarEntry>();
         ArrayList<String> xVals = new ArrayList<String>();
-        Log.e("##", xVals.size() + "");
+        Log.e("##", Integer.toString(xVals.size()));
         for (int i = 0, j = 0; i < mData.getDatas().size(); i++, j++) {
            /* //避免数据重复，skip也能正常显示
             if (mData.getDatas().get(i).time.equals("13:30")) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131 - “Primitives should not be boxed just for "String" conversion”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131

Please let me know if you have any questions.
Ayman Abdelghany.
