### PR TITLE
[squid:S1197] Array designators "[]" should be on the type, not the variable

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/highlight/CombinedHighlighter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/highlight/CombinedHighlighter.java
@@ -46,7 +46,7 @@ public class CombinedHighlighter extends ChartHighlighter<BarLineScatterCandleBu
                     continue;
 
                 // extract all y-values from all DataSets at the given x-index
-                final float yVals[] = dataSet.getYValsForXIndex(xIndex);
+                final float[] yVals = dataSet.getYValsForXIndex(xIndex);
                 for (float yVal : yVals) {
                     pts[1] = yVal;
 

--- a/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
@@ -202,7 +202,7 @@ public abstract class Utils {
      * Math.pow(...) is very expensive, so avoid calling it and create it
      * yourself.
      */
-    private static final int POW_10[] = {
+    private static final int[] POW_10 = {
             1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000
     };
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1197 - “Array designators "[]" should be on the type, not the variable”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.
Ayman Abdelghany.
