### PR TITLE
[squid:S1168] Empty arrays and collections should be returned instead of null

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/data/ChartData.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/ChartData.java
@@ -771,7 +771,7 @@ public abstract class ChartData<T extends IDataSet<? extends Entry>> {
     public int[] getColors() {
 
         if (mDataSets == null)
-            return null;
+            return new int[0];
 
         int clrcnt = 0;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1168 - “Empty arrays and collections should be returned instead of null”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1168

Please let me know if you have any questions.
Ayman Abdelghany.
