### PR TITLE
[squid:S1161] "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/utils/PointD.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/PointD.java
@@ -19,6 +19,7 @@ public class PointD {
     /**
      * returns a string representation of the object
      */
+    @Override
     public String toString() {
         return "PointD, x: " + x + ", y: " + y;
     }

--- a/app/src/main/java/com/example/yanjiang/stockchart/rxutils/ExecutorManager.java
+++ b/app/src/main/java/com/example/yanjiang/stockchart/rxutils/ExecutorManager.java
@@ -27,6 +27,7 @@ public class ExecutorManager {
     private static final ThreadFactory eventThreadFactory = new ThreadFactory() {
         private final AtomicInteger mCount = new AtomicInteger(1);
 
+        @Override
         public Thread newThread(@NonNull Runnable r) {
             return new Thread(r, "eventAsyncAndBackground #" + mCount.getAndIncrement());
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1161 - “ "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1161

Please let me know if you have any questions.
Ayman Abdelghany.
