### PR TITLE
[squid:S1848] Objects should not be created to be dropped immediately without being used

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/PieRadarChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/PieRadarChartBase.java
@@ -282,9 +282,8 @@ public abstract class PieRadarChartBase<T extends ChartData<? extends IDataSet<?
      */
     protected PointF getPosition(PointF center, float dist, float angle) {
 
-        PointF p = new PointF((float) (center.x + dist * Math.cos(Math.toRadians(angle))),
+        return new PointF((float) (center.x + dist * Math.cos(Math.toRadians(angle))),
                 (float) (center.y + dist * Math.sin(Math.toRadians(angle))));
-        return p;
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/data/BubbleEntry.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/BubbleEntry.java
@@ -42,9 +42,7 @@ public class BubbleEntry extends Entry {
 
     public BubbleEntry copy() {
 
-        BubbleEntry c = new BubbleEntry(getXIndex(), getVal(), mSize, getData());
-
-        return c;
+        return new BubbleEntry(getXIndex(), getVal(), mSize, getData());
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/data/CandleEntry.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/CandleEntry.java
@@ -88,10 +88,8 @@ public class CandleEntry extends Entry {
 
     public CandleEntry copy() {
 
-        CandleEntry c = new CandleEntry(getXIndex(), mShadowHigh, mShadowLow, mOpen,
+        return new CandleEntry(getXIndex(), mShadowHigh, mShadowLow, mOpen,
                 mClose, getData());
-
-        return c;
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/data/Entry.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/Entry.java
@@ -107,8 +107,7 @@ public class Entry extends ChartData<DataSet<? extends Entry>> {
      * @return
      */
     public Entry copy() {
-        Entry e = new Entry(mVal, mXIndex, mData);
-        return e;
+        return new Entry(mVal, mXIndex, mData);
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/data/filter/Approximator.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/filter/Approximator.java
@@ -259,9 +259,7 @@ public class Approximator {
 
         float dx = p2.getXIndex() * mDeltaRatio - p1.getXIndex() * mDeltaRatio;
         float dy = p2.getVal() * mScaleRatio - p1.getVal() * mScaleRatio;
-        double angle = Math.atan2(dy, dx) * 180.0 / Math.PI;
-
-        return angle;
+        return Math.atan2(dy, dx) * 180.0 / Math.PI;
     }
 
     /**
@@ -275,8 +273,6 @@ public class Approximator {
 
         float dx = p2.getXIndex() - p1.getXIndex();
         float dy = p2.getVal() - p1.getVal();
-        double angle = Math.atan2(dy, dx) * 180.0 / Math.PI;
-
-        return angle;
+        return Math.atan2(dy, dx) * 180.0 / Math.PI;
     }
 }

--- a/MPChartLib/src/com/github/mikephil/charting/highlight/BarHighlighter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/highlight/BarHighlighter.java
@@ -213,8 +213,7 @@ public class BarHighlighter extends ChartHighlighter<BarDataProvider> {
 
 		float groupSpaceSum = mChart.getBarData().getGroupSpace() * (float) steps;
 
-		float baseNoSpace = (float) xVal - groupSpaceSum;
-		return baseNoSpace;
+		return (float) xVal - groupSpaceSum;
 	}
 
 	/**

--- a/MPChartLib/src/com/github/mikephil/charting/highlight/ChartHighlighter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/highlight/ChartHighlighter.java
@@ -77,9 +77,7 @@ public class ChartHighlighter<T extends BarLineScatterCandleBubbleDataProvider> 
 
 		YAxis.AxisDependency axis = leftdist < rightdist ? YAxis.AxisDependency.LEFT : YAxis.AxisDependency.RIGHT;
 
-		SelectionDetail detail = Utils.getClosestSelectionDetailByPixelY(valsAtIndex, y, axis);
-
-		return detail;
+		return Utils.getClosestSelectionDetailByPixelY(valsAtIndex, y, axis);
 	}
 
 	/**

--- a/MPChartLib/src/com/github/mikephil/charting/highlight/HorizontalBarHighlighter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/highlight/HorizontalBarHighlighter.java
@@ -113,7 +113,6 @@ public class HorizontalBarHighlighter extends BarHighlighter {
 
 		float groupSpaceSum = mChart.getBarData().getGroupSpace() * (float) steps;
 
-		float baseNoSpace = (float) yVal - groupSpaceSum;
-		return baseNoSpace;
+		return (float) yVal - groupSpaceSum;
 	}
 }

--- a/MPChartLib/src/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
+++ b/MPChartLib/src/com/github/mikephil/charting/listener/BarLineChartTouchListener.java
@@ -464,8 +464,7 @@ public class BarLineChartTouchListener extends ChartTouchListener<BarLineChartBa
      * @return
      */
     private static float getXDist(MotionEvent e) {
-        float x = Math.abs(e.getX(0) - e.getX(1));
-        return x;
+        return Math.abs(e.getX(0) - e.getX(1));
     }
 
     /**
@@ -476,8 +475,7 @@ public class BarLineChartTouchListener extends ChartTouchListener<BarLineChartBa
      * @return
      */
     private static float getYDist(MotionEvent e) {
-        float y = Math.abs(e.getY(0) - e.getY(1));
-        return y;
+        return Math.abs(e.getY(0) - e.getY(1));
     }
 
     /**

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
@@ -64,8 +64,7 @@ public class BubbleChartRenderer extends DataRenderer {
         final float factor = normalizeSize
                 ? ((maxSize == 0f) ? 1f : (float) Math.sqrt(entrySize / maxSize))
                 : entrySize;
-        final float shapeSize = reference * factor;
-        return shapeSize;
+        return reference * factor;
     }
 
     protected void drawDataSet(Canvas c, IBubbleDataSet dataSet) {

--- a/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
@@ -116,8 +116,7 @@ public abstract class Utils {
         }
 
         DisplayMetrics metrics = mMetrics;
-        float px = dp * (metrics.densityDpi / 160f);
-        return px;
+        return dp * (metrics.densityDpi / 160f);
     }
 
     /**
@@ -142,8 +141,7 @@ public abstract class Utils {
         }
 
         DisplayMetrics metrics = mMetrics;
-        float dp = px / (metrics.densityDpi / 160f);
-        return dp;
+        return px / (metrics.densityDpi / 160f);
     }
 
     /**
@@ -545,9 +543,8 @@ public abstract class Utils {
      */
     public static PointF getPosition(PointF center, float dist, float angle) {
 
-        PointF p = new PointF((float) (center.x + dist * Math.cos(Math.toRadians(angle))),
+        return new PointF((float) (center.x + dist * Math.cos(Math.toRadians(angle))),
                 (float) (center.y + dist * Math.sin(Math.toRadians(angle))));
-        return p;
     }
 
     public static void velocityTrackerPointerUpCleanUpIfNecessary(MotionEvent ev,

--- a/app/src/main/java/com/example/yanjiang/stockchart/inject/modules/ClientApiModule.java
+++ b/app/src/main/java/com/example/yanjiang/stockchart/inject/modules/ClientApiModule.java
@@ -51,14 +51,12 @@ public class ClientApiModule {
     @Provides
     @Singleton
     public OkHttpClient provideOkHttpClient(Context context, HttpLoggingInterceptor httpLoggingInterceptor) {
-        OkHttpClient client = new OkHttpClient.Builder()
+        return new OkHttpClient.Builder()
                 .connectTimeout(10, TimeUnit.SECONDS)
                 .writeTimeout(10, TimeUnit.SECONDS)
                 .readTimeout(30, TimeUnit.SECONDS)
                 .addInterceptor(httpLoggingInterceptor)
                 .build();
-
-        return client;
     }
 
     @Provides


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1848 - “Objects should not be created to be dropped immediately without being used”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1848

Please let me know if you have any questions.
Ayman Abdelghany.
