### PR TITLE
[squid:UselessImportCheck] Useless imports should be removed

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/animation/ChartAnimator.java
+++ b/MPChartLib/src/com/github/mikephil/charting/animation/ChartAnimator.java
@@ -3,7 +3,6 @@ package com.github.mikephil.charting.animation;
 
 import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator.AnimatorUpdateListener;
-import android.annotation.SuppressLint;
 
 /**
  * Object responsible for all animations in the Chart. ANIMATIONS ONLY WORK FOR

--- a/MPChartLib/src/com/github/mikephil/charting/buffer/AbstractBuffer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/buffer/AbstractBuffer.java
@@ -1,7 +1,6 @@
 
 package com.github.mikephil.charting.buffer;
 
-import java.util.List;
 
 /**
  * Buffer class to boost performance while drawing. Concept: Replace instead of

--- a/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/BarLineChartBase.java
@@ -15,8 +15,6 @@ import android.util.AttributeSet;
 import android.util.Log;
 import android.view.MotionEvent;
 
-import com.github.mikephil.charting.components.Legend;
-import com.github.mikephil.charting.components.Legend.LegendPosition;
 import com.github.mikephil.charting.components.XAxis.XAxisPosition;
 import com.github.mikephil.charting.components.YAxis;
 import com.github.mikephil.charting.components.YAxis.AxisDependency;

--- a/MPChartLib/src/com/github/mikephil/charting/charts/HorizontalBarChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/HorizontalBarChart.java
@@ -7,7 +7,6 @@ import android.graphics.RectF;
 import android.util.AttributeSet;
 import android.util.Log;
 
-import com.github.mikephil.charting.components.Legend.LegendPosition;
 import com.github.mikephil.charting.components.XAxis.XAxisPosition;
 import com.github.mikephil.charting.components.YAxis.AxisDependency;
 import com.github.mikephil.charting.data.BarEntry;

--- a/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/PieChart.java
@@ -15,7 +15,6 @@ import com.github.mikephil.charting.data.PieData;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.datasets.IPieDataSet;
 import com.github.mikephil.charting.renderer.PieChartRenderer;
-import com.github.mikephil.charting.utils.ColorTemplate;
 import com.github.mikephil.charting.utils.Utils;
 
 import java.util.List;

--- a/MPChartLib/src/com/github/mikephil/charting/charts/PieRadarChartBase.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/PieRadarChartBase.java
@@ -14,7 +14,6 @@ import android.view.MotionEvent;
 
 import com.github.mikephil.charting.animation.Easing;
 import com.github.mikephil.charting.components.Legend;
-import com.github.mikephil.charting.components.Legend.LegendPosition;
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.data.ChartData;
 import com.github.mikephil.charting.data.Entry;

--- a/MPChartLib/src/com/github/mikephil/charting/components/LimitLine.java
+++ b/MPChartLib/src/com/github/mikephil/charting/components/LimitLine.java
@@ -4,7 +4,6 @@ package com.github.mikephil.charting.components;
 import android.graphics.Color;
 import android.graphics.DashPathEffect;
 import android.graphics.Paint;
-import android.graphics.Typeface;
 
 import com.github.mikephil.charting.utils.Utils;
 

--- a/MPChartLib/src/com/github/mikephil/charting/data/BubbleDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/BubbleDataSet.java
@@ -1,7 +1,6 @@
 
 package com.github.mikephil.charting.data;
 
-import android.graphics.Color;
 
 import com.github.mikephil.charting.interfaces.datasets.IBubbleDataSet;
 import com.github.mikephil.charting.utils.Utils;

--- a/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/LineDataSet.java
@@ -4,7 +4,6 @@ package com.github.mikephil.charting.data;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.DashPathEffect;
-import android.graphics.drawable.Drawable;
 
 import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
 import com.github.mikephil.charting.utils.ColorTemplate;

--- a/MPChartLib/src/com/github/mikephil/charting/data/realm/base/RealmBaseDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/realm/base/RealmBaseDataSet.java
@@ -1,6 +1,5 @@
 package com.github.mikephil.charting.data.realm.base;
 
-import com.github.mikephil.charting.data.BarEntry;
 import com.github.mikephil.charting.data.BaseDataSet;
 import com.github.mikephil.charting.data.DataSet;
 import com.github.mikephil.charting.data.Entry;

--- a/MPChartLib/src/com/github/mikephil/charting/data/realm/base/RealmLineRadarDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/realm/base/RealmLineRadarDataSet.java
@@ -7,7 +7,6 @@ import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.interfaces.datasets.ILineRadarDataSet;
 import com.github.mikephil.charting.utils.Utils;
 
-import io.realm.DynamicRealmObject;
 import io.realm.RealmObject;
 import io.realm.RealmResults;
 

--- a/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmBarDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmBarDataSet.java
@@ -3,7 +3,6 @@ package com.github.mikephil.charting.data.realm.implementation;
 import android.graphics.Color;
 
 import com.github.mikephil.charting.data.BarEntry;
-import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.realm.base.RealmBarLineScatterCandleBubbleDataSet;
 import com.github.mikephil.charting.interfaces.datasets.IBarDataSet;
 

--- a/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmBubbleDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmBubbleDataSet.java
@@ -1,7 +1,6 @@
 package com.github.mikephil.charting.data.realm.implementation;
 
 import com.github.mikephil.charting.data.BubbleEntry;
-import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.realm.base.RealmBarLineScatterCandleBubbleDataSet;
 import com.github.mikephil.charting.interfaces.datasets.IBubbleDataSet;
 import com.github.mikephil.charting.utils.Utils;

--- a/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmCandleDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmCandleDataSet.java
@@ -3,7 +3,6 @@ package com.github.mikephil.charting.data.realm.implementation;
 import android.graphics.Paint;
 
 import com.github.mikephil.charting.data.CandleEntry;
-import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.realm.base.RealmLineScatterCandleRadarDataSet;
 import com.github.mikephil.charting.interfaces.datasets.ICandleDataSet;
 import com.github.mikephil.charting.utils.ColorTemplate;

--- a/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmPieDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmPieDataSet.java
@@ -6,7 +6,6 @@ import com.github.mikephil.charting.data.realm.base.RealmBaseDataSet;
 import com.github.mikephil.charting.interfaces.datasets.IPieDataSet;
 import com.github.mikephil.charting.utils.Utils;
 
-import io.realm.DynamicRealmObject;
 import io.realm.RealmObject;
 import io.realm.RealmResults;
 

--- a/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmScatterDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmScatterDataSet.java
@@ -5,9 +5,7 @@ import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.realm.base.RealmLineScatterCandleRadarDataSet;
 import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
 import com.github.mikephil.charting.utils.ColorTemplate;
-import com.github.mikephil.charting.utils.Utils;
 
-import io.realm.DynamicRealmObject;
 import io.realm.RealmObject;
 import io.realm.RealmResults;
 

--- a/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
@@ -1,7 +1,6 @@
 package com.github.mikephil.charting.interfaces.datasets;
 
 import android.graphics.DashPathEffect;
-import android.graphics.drawable.Drawable;
 
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.LineDataSet;

--- a/MPChartLib/src/com/github/mikephil/charting/jobs/AnimatedMoveViewJob.java
+++ b/MPChartLib/src/com/github/mikephil/charting/jobs/AnimatedMoveViewJob.java
@@ -1,8 +1,6 @@
 package com.github.mikephil.charting.jobs;
 
-import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator;
-import android.annotation.SuppressLint;
 import android.view.View;
 
 import com.github.mikephil.charting.utils.Transformer;

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/BarChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/BarChartRenderer.java
@@ -7,7 +7,6 @@ import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.RectF;
-import android.util.Log;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.buffer.BarBuffer;

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/BubbleChartRenderer.java
@@ -11,7 +11,6 @@ import com.github.mikephil.charting.data.BubbleEntry;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.dataprovider.BubbleDataProvider;
 import com.github.mikephil.charting.interfaces.datasets.IBubbleDataSet;
-import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
 import com.github.mikephil.charting.utils.Transformer;
 import com.github.mikephil.charting.utils.Utils;
 import com.github.mikephil.charting.utils.ViewPortHandler;

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -9,7 +9,6 @@ import android.graphics.drawable.Drawable;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.charts.LineChart;
-import com.github.mikephil.charting.data.BarData;
 import com.github.mikephil.charting.data.DataSet;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.LineData;

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/LineRadarRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/LineRadarRenderer.java
@@ -3,8 +3,6 @@ package com.github.mikephil.charting.renderer;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Path;
-import android.graphics.PorterDuff;
-import android.graphics.PorterDuffXfermode;
 import android.graphics.drawable.Drawable;
 
 import com.github.mikephil.charting.animation.ChartAnimator;

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRendererHorizontalBarChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/YAxisRendererHorizontalBarChart.java
@@ -7,7 +7,6 @@ import android.graphics.Paint.Align;
 import android.graphics.Path;
 
 import com.github.mikephil.charting.components.LimitLine;
-import com.github.mikephil.charting.components.LimitLine.LimitLabelPosition;
 import com.github.mikephil.charting.components.YAxis;
 import com.github.mikephil.charting.components.YAxis.AxisDependency;
 import com.github.mikephil.charting.components.YAxis.YAxisLabelPosition;

--- a/MPChartLib/src/com/github/mikephil/charting/utils/ViewPortHandler.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/ViewPortHandler.java
@@ -4,7 +4,6 @@ package com.github.mikephil.charting.utils;
 import android.graphics.Matrix;
 import android.graphics.PointF;
 import android.graphics.RectF;
-import android.util.Log;
 import android.view.View;
 
 /**

--- a/app/src/main/java/com/example/yanjiang/stockchart/application/App.java
+++ b/app/src/main/java/com/example/yanjiang/stockchart/application/App.java
@@ -1,7 +1,6 @@
 package com.example.yanjiang.stockchart.application;
 
 import android.app.Application;
-import android.os.Handler;
 
 import com.example.yanjiang.stockchart.BuildConfig;
 import com.example.yanjiang.stockchart.inject.component.AppComponent;

--- a/app/src/main/java/com/example/yanjiang/stockchart/inject/modules/ClientApiModule.java
+++ b/app/src/main/java/com/example/yanjiang/stockchart/inject/modules/ClientApiModule.java
@@ -8,7 +8,6 @@ import android.preference.PreferenceManager;
 import com.example.yanjiang.stockchart.BuildConfig;
 import com.example.yanjiang.stockchart.api.ClientApi;
 import com.example.yanjiang.stockchart.api.Constant;
-import com.example.yanjiang.stockchart.interceptor.HttpInterceptor;
 
 import java.util.concurrent.TimeUnit;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessImportCheck - “Useless imports should be removed”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessImportCheck

Please let me know if you have any questions.
Ayman Abdelghany.
