### PR TITLE
[squid:ModifiersOrderCheck] Modifiers should be declared in the corre

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
+++ b/MPChartLib/src/com/github/mikephil/charting/utils/Utils.java
@@ -38,8 +38,8 @@ public abstract class Utils {
     private static DisplayMetrics mMetrics;
     private static int mMinimumFlingVelocity = 50;
     private static int mMaximumFlingVelocity = 8000;
-    public final static double DEG2RAD = (Math.PI / 180.0);
-    public final static float FDEG2RAD = ((float) Math.PI / 180.f);
+    public static final double DEG2RAD = (Math.PI / 180.0);
+    public static final float FDEG2RAD = ((float) Math.PI / 180.f);
     
     /**
      * Prevent class instantiation.

--- a/app/src/main/java/com/example/yanjiang/stockchart/interceptor/HttpInterceptor.java
+++ b/app/src/main/java/com/example/yanjiang/stockchart/interceptor/HttpInterceptor.java
@@ -18,9 +18,9 @@ import okhttp3.ResponseBody;
  */
 public class HttpInterceptor implements Interceptor {
     private static String mBoundry;
-    private final static int boundaryLength = 32;
+    private static final int boundaryLength = 32;
     private Context context;
-    private final static String boundaryAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
+    private static final String boundaryAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
 
     public HttpInterceptor(Context context) {
         this.context = context;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ModifiersOrderCheck - “Modifiers should be declared in the correct order”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.
Ayman Abdelghany.
