### PR TITLE
[squid:S1905] Redundant casts should not be used

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/highlight/BarHighlighter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/highlight/BarHighlighter.java
@@ -210,11 +210,11 @@ public class BarHighlighter extends ChartHighlighter<BarDataProvider> {
 		int setCount = mChart.getBarData().getDataSetCount();
 
 		// calculate how often the group-space appears
-		int steps = (int) ((float) xVal / ((float) setCount + mChart.getBarData().getGroupSpace()));
+		int steps = (int) (xVal / ((float) setCount + mChart.getBarData().getGroupSpace()));
 
 		float groupSpaceSum = mChart.getBarData().getGroupSpace() * (float) steps;
 
-		return (float) xVal - groupSpaceSum;
+		return xVal - groupSpaceSum;
 	}
 
 	/**

--- a/MPChartLib/src/com/github/mikephil/charting/highlight/ChartHighlighter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/highlight/ChartHighlighter.java
@@ -57,7 +57,7 @@ public class ChartHighlighter<T extends BarLineScatterCandleBubbleDataProvider> 
 		// take any transformer to determine the x-axis value
 		mChart.getTransformer(YAxis.AxisDependency.LEFT).pixelsToValue(pts);
 
-		return (int) Math.round(pts[0]);
+		return Math.round(pts[0]);
 	}
 
 	/**

--- a/MPChartLib/src/com/github/mikephil/charting/highlight/HorizontalBarHighlighter.java
+++ b/MPChartLib/src/com/github/mikephil/charting/highlight/HorizontalBarHighlighter.java
@@ -70,7 +70,7 @@ public class HorizontalBarHighlighter extends BarHighlighter {
 			// take any transformer to determine the x-axis value
 			mChart.getTransformer(YAxis.AxisDependency.LEFT).pixelsToValue(pts);
 
-			return (int) Math.round(pts[1]);
+			return Math.round(pts[1]);
 		} else {
 
 			float baseNoSpace = getBase(x);
@@ -109,10 +109,10 @@ public class HorizontalBarHighlighter extends BarHighlighter {
 		int setCount = mChart.getBarData().getDataSetCount();
 
 		// calculate how often the group-space appears
-		int steps = (int) ((float) yVal / ((float) setCount + mChart.getBarData().getGroupSpace()));
+		int steps = (int) (yVal / ((float) setCount + mChart.getBarData().getGroupSpace()));
 
 		float groupSpaceSum = mChart.getBarData().getGroupSpace() * (float) steps;
 
-		return (float) yVal - groupSpaceSum;
+		return yVal - groupSpaceSum;
 	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1905 - “Redundant casts should not be used”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1905

Please let me know if you have any questions.
Ayman Abdelghany.
