### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ StockChart包括分时图，k线图等实现，欢迎star<br><br>
 <br><br>
 
 
-#Thanks 
+# Thanks 
 特别感谢外国友人[AymanDF]
 (https://github.com/AymanDF)对本代码的优化
 同时也很感谢[WinWang] 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
